### PR TITLE
修改PUBREL报文固定报头错误

### DIFF
--- a/mqtt/0306-PUBREL.md
+++ b/mqtt/0306-PUBREL.md
@@ -25,9 +25,9 @@ PUBREL报文是对PUBREC报文的响应。它是QoS 2等级协议交换的第三
    </tr>
    <tr>
        <td></td>
-       <td align="center">1</td>
-       <td align="center">1</td>
        <td align="center">0</td>
+       <td align="center">1</td>
+       <td align="center">1</td>
        <td align="center">0</td>
        <td align="center">0</td>
        <td align="center">0</td>


### PR DESCRIPTION
MQTT控制报文类型 (6)，原来是1100是错误的，改成0110